### PR TITLE
Fix type mismatch in cypher bi13

### DIFF
--- a/cypher/queries/bi-13.cypher
+++ b/cypher/queries/bi-13.cypher
@@ -5,8 +5,8 @@
 MATCH (country:Country {name: $country})<-[:IS_PART_OF]-(:City)<-[:IS_LOCATED_IN]-(zombie:Person)
 OPTIONAL MATCH
   (zombie)<-[:HAS_CREATOR]-(message:Message)
-WHERE zombie.creationDate  < $endDate.year
-  AND message.creationDate < $endDate.month
+WHERE zombie.creationDate  < $endDate
+  AND message.creationDate < $endDate
 WITH
   country,
   zombie,


### PR DESCRIPTION
bi13 was previously comparing instant types against integer types.

While this PR fixes the type mismatch, it's worth noting that this is still different from the SQL version of bi13 which compares the message creation date against the zombie creation date as well.