### PR TITLE
Change avg to sum/count in bi-1 for better consistency across implementation

### DIFF
--- a/cypher/queries/bi-1.cypher
+++ b/cypher/queries/bi-1.cypher
@@ -24,7 +24,7 @@ WITH
     ELSE                           3
   END AS lengthCategory,
   count(message) AS messageCount,
-  floor(avg(message.length)) AS averageMessageLength,
+  floor(sum(message.length) / count(message)) AS averageMessageLength,
   sum(message.length) AS sumMessageLength
 RETURN
   year,


### PR DESCRIPTION
neo4j considers the result of the call to `floor(avg(message.length))` on a row with `sumMessageLength=48` and `messageCount=12` as `3` (due to floating point inaccuracy the result of avg ends up being `3.9999999999999996`). For a result that's more likely to be consistent across multiple implementations that may implement the floating point arithmetic differently, using `round` instead of `floor` circumvents this issue.

Neo4j Results with `round`:

```
+--------------------------------------------------------------------------------------------------------------------+
| year | isComment | lengthCategory | messageCount | averageMessageLength | sumMessageLength | percentageOfMessages  |
+--------------------------------------------------------------------------------------------------------------------+
| 2011 | FALSE     | 2              | 15           | 102.0                | 1537             | 0.010094212651413189  |
| 2011 | FALSE     | 3              | 6            | 195.0                | 1169             | 0.004037685060565276  |
| 2011 | TRUE      | 0              | 12           | 4.0                  | 48               | 0.008075370121130552  |
| 2011 | TRUE      | 1              | 1            | 76.0                 | 76               | 6.729475100942127E-4  |
| 2011 | TRUE      | 2              | 3            | 107.0                | 321              | 0.002018842530282638  |
| 2010 | FALSE     | 2              | 4            | 108.0                | 430              | 0.0026917900403768506 |
| 2010 | FALSE     | 3              | 2            | 210.0                | 419              | 0.0013458950201884253 |
+--------------------------------------------------------------------------------------------------------------------+
```

Neo4j results with `floor`:

```
+--------------------------------------------------------------------------------------------------------------------+
| year | isComment | lengthCategory | messageCount | averageMessageLength | sumMessageLength | percentageOfMessages  |
+--------------------------------------------------------------------------------------------------------------------+
| 2011 | FALSE     | 2              | 15           | 102.0                | 1537             | 0.010094212651413189  |
| 2011 | FALSE     | 3              | 6            | 194.0                | 1169             | 0.004037685060565276  |
| 2011 | TRUE      | 0              | 12           | 3.0                  | 48               | 0.008075370121130552  |
| 2011 | TRUE      | 1              | 1            | 76.0                 | 76               | 6.729475100942127E-4  |
| 2011 | TRUE      | 2              | 3            | 107.0                | 321              | 0.002018842530282638  |
| 2010 | FALSE     | 2              | 4            | 107.0                | 430              | 0.0026917900403768506 |
| 2010 | FALSE     | 3              | 2            | 209.0                | 419              | 0.0013458950201884253 |
+--------------------------------------------------------------------------------------------------------------------+
```

